### PR TITLE
[build] make build work well

### DIFF
--- a/src/aslp-nnet/Makefile
+++ b/src/aslp-nnet/Makefile
@@ -26,7 +26,7 @@ endif
 
 LIBNAME = aslp-nnet
 
-ADDLIBS = ../aslp-cudamatrix/aslp-cudamatrix.a \
+ADDLIBS = ../hmm/kaldi-hmm.a ../aslp-cudamatrix/aslp-cudamatrix.a \
           ../matrix/kaldi-matrix.a \
           ../base/kaldi-base.a \
           ../util/kaldi-util.a 

--- a/src/aslp-parallelbin/aslp-nnet-train-server.cc
+++ b/src/aslp-parallelbin/aslp-nnet-train-server.cc
@@ -17,6 +17,7 @@
 #include "aslp-parallel/itf.h"
 #include "aslp-parallel/easgd-server.h"
 #include "aslp-parallel/asgd-server.h"
+#include "aslp-parallel/masgd-server.h"
 
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Hi, Binbin
When I install kaldi-aslp in two Linux machines, the build process in src/ runs with errors for lack of a lib file and a header file. After add these things, the build process works fine.
Thanks
Kaituo